### PR TITLE
Update binary_training.ipynb

### DIFF
--- a/notebooks/binary_training.ipynb
+++ b/notebooks/binary_training.ipynb
@@ -214,6 +214,8 @@
    },
    "outputs": [],
    "source": [
+    "from skimage.transform import resize\n",
+    "\n",
     "def get_data(folder):\n",
     "    \"\"\"\n",
     "    Load the data and labels from the given folder.\n",
@@ -231,7 +233,7 @@
     "                img_file = cv2.imread(folder + wbc_type + '/' + image_filename)\n",
     "                if img_file is not None:\n",
     "                    # Downsample the image to 120, 160, 3\n",
-    "                    img_file = scipy.misc.imresize(arr=img_file, size=(120, 160, 3))\n",
+    "                    img_file = resize(img_file, (120, 160, 3))\n",
     "                    img_arr = np.asarray(img_file)\n",
     "                    X.append(img_arr)\n",
     "                    y.append(label)\n",


### PR DESCRIPTION
scipy.misc.imresize is depreciated now. So we use skimage.transform.resize instead.